### PR TITLE
Vocab version

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,4 @@ compare_versions
 ^doc$
 ^Meta$
 inst/shiny/DiagnosticsExplorer/renv
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ renv.lock
 MergedCohortDiagnosticsData.7z
 inst/shiny/DiagnosticsExplorer/UserCredentials.csv
 inst/doc
+results/

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -675,6 +675,15 @@ executeDiagnostics <- function(cohortDefinitionSet,
     )
   }
 
+  
+  # Defines external concept counts table variables ----------------------
+  if (useExternalConceptCountsTable == FALSE) {
+    conceptCountsTableIsTemp <- TRUE
+  } else {
+    conceptCountsTableIsTemp <- FALSE
+    conceptCountsTable <- "concept_counts"
+  }
+  
   # Concept set diagnostics -----------------------------------------------
   if (runIncludedSourceConcepts ||
     runOrphanConcepts ||
@@ -697,9 +706,9 @@ executeDiagnostics <- function(cohortDefinitionSet,
           runBreakdownIndexEvents = runBreakdownIndexEvents,
           exportFolder = exportFolder,
           minCellCount = minCellCount,
-          conceptCountsDatabaseSchema = NULL,
+          conceptCountsDatabaseSchema = cohortDatabaseSchema,
           conceptCountsTable = conceptCountsTable,
-          conceptCountsTableIsTemp = TRUE,
+          conceptCountsTableIsTemp = conceptCountsTableIsTemp,
           cohortDatabaseSchema = cohortDatabaseSchema,
           cohortTable = cohortTable,
           useExternalConceptCountsTable = useExternalConceptCountsTable,

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -676,12 +676,28 @@ executeDiagnostics <- function(cohortDefinitionSet,
   }
 
   
-  # Defines external concept counts table variables ----------------------
+  # Defines variables and checcs version of external concept counts table ----------------------
   if (useExternalConceptCountsTable == FALSE) {
     conceptCountsTableIsTemp <- TRUE
   } else {
     conceptCountsTableIsTemp <- FALSE
     conceptCountsTable <- "concept_counts"
+    vocabVersion <- DatabaseConnector::renderTranslateQuerySql(
+      connection = connection,
+      sql = "SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = 'None';",
+      cdm_database_schema = cdmDatabaseSchema,
+      snakeCaseToCamelCase = TRUE,
+      tempEmulationSchema = getOption("sqlRenderTempEmulationSchena")
+    )
+    vocabVersionuseExternalConceptCountsTable <- DatabaseConnector::renderTranslateQuerySql(
+      connection = connection,
+      sql = "SELECT DISTINCT vocabulary_version FROM @work_database_schema.@concept_counts_table;",
+      work_database_schema = cohortDatabaseSchema,
+      concept_counts_table = conceptCountsTable,
+      snakeCaseToCamelCase = TRUE,
+      tempEmulationSchema = getOption("sqlRenderTempEmulationSchena")
+    )
+    checkmate::assertTRUE(identical(vocabVersion[1,1], vocabVersionuseExternalConceptCountsTable[1,1]))
   }
   
   # Concept set diagnostics -----------------------------------------------

--- a/inst/sql/sql_server/CreateConceptCountTable.sql
+++ b/inst/sql/sql_server/CreateConceptCountTable.sql
@@ -97,3 +97,22 @@ FROM (
 	FROM @cdm_database_schema.observation
 	GROUP BY observation_source_concept_id
 	) tmp;
+
+
+{@table_is_temp} ? {
+
+
+
+ALTER TABLE @concept_counts_table
+ADD vocabulary_version VARCHAR(20) NULL;
+UPDATE @concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = "None");
+} : { 
+ALTER TABLE @work_database_schema.@concept_counts_table
+ADD vocabulary_version VARCHAR(20) NULL;
+UPDATE @work_database_schema.@concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = "None");
+}
+
+
+
+
+

--- a/inst/sql/sql_server/CreateConceptCountTable.sql
+++ b/inst/sql/sql_server/CreateConceptCountTable.sql
@@ -105,11 +105,11 @@ FROM (
 
 ALTER TABLE @concept_counts_table
 ADD vocabulary_version VARCHAR(20) NULL;
-UPDATE @concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = "None");
+UPDATE @concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = 'None');
 } : { 
 ALTER TABLE @work_database_schema.@concept_counts_table
 ADD vocabulary_version VARCHAR(20) NULL;
-UPDATE @work_database_schema.@concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = "None");
+UPDATE @work_database_schema.@concept_counts_table SET vocabulary_version = (SELECT vocabulary_version FROM @cdm_database_schema.vocabulary WHERE vocabulary_id = 'None');
 }
 
 


### PR DESCRIPTION
- Fixed variables that prevented executing the diagnostics on Eunomia. 

- When externalConceptCountsTable is created, a column with the version of the vocabulary is added. 

- When running the diagnostics, it checks thatexternalConceptCountsTable corresponds to the actual version of the database we are working in. 

- Tested on Postgresql and Eunomia