### PR TITLE
Issue 96

### DIFF
--- a/R/checkArg.R
+++ b/R/checkArg.R
@@ -10,10 +10,10 @@
 checkArg <- function(arg, add) {
   
   argName <- deparse(substitute(arg))
-  
+
   if (argName == "connection") {
     checkmate::assertClass(arg, "DatabaseConnectorConnection")
-    checkmate::assertTRUE(DatabaseConnector::dbIsValid(connection))
+    checkmate::assertTRUE(DatabaseConnector::dbIsValid(arg))
     
   } else if (argName %in% c("tempEmulationSchema", "cdmDatabaseSchema", "vocabularyDatabaseSchema", "cohortDatabaseSchema")) {
     checkmate::assertCharacter(arg, len = 1, pattern = "^[A-Za-z][A-Za-z0-9_]*$", null.ok = TRUE)
@@ -56,7 +56,7 @@ checkArg <- function(arg, add) {
     checkmate::assertNumeric(x = arg, lower = 0, add = add, any.missing = FALSE)
     
   } else if (argName == "incremental") {
-    checkmate::assertLogical(arg, add = add, len = 1, add = add, any.missing = FALSE)
+    checkmate::assertLogical(arg, add = add, len = 1, any.missing = FALSE)
     
   } else if (argName == "cohortTable") {
     checkmate::assertCharacter(x = arg, min.len = 1, pattern = "^[A-Za-z][A-Za-z0-9_]*$", add = add, any.missing = FALSE)

--- a/R/runCohortCharacterization.R
+++ b/R/runCohortCharacterization.R
@@ -343,11 +343,6 @@ getCohortCharacteristics <- function(connection = NULL,
 #' @param covariateSettings          Either an object of type \code{covariateSettings} as created using one of
 #'                                   the createTemporalCovariateSettings function in the FeatureExtraction package, or a list
 #'                                   of such objects.
-#' @param covariateValueFileName     Filename of the binary covariates output
-#' @param covariateValueContFileName Filename of the continuous covariate output
-#' @param covariateRefFileName       Filename of the covariate reference output
-#' @param analysisRefFileName        Filename of the analysis reference output
-#' @param timeRefFileName            Filename of the time reference output
 #' @param minCharacterizationMean    The minimum mean value for characterization output. Values below this will be cut off from output. This
 #'                                   will help reduce the file size of the characterization output, but will remove information
 #'                                   on covariates that have very low values. The default is 0.001 (i.e. 0.1 percent)
@@ -373,6 +368,18 @@ runCohortCharacterization <- function(connection,
                                       recordKeepingFile,
                                       minCharacterizationMean = 0.001,
                                       batchSize = getOption("CohortDiagnostics-FE-batch-size", default = 20)) {
+  
+  # Filename of the binary covariates output
+  covariateValueFileName = file.path(exportFolder, "temporal_covariate_value.csv")
+  # Filename of the covariate reference output
+  covariateRefFileName = file.path(exportFolder, "temporal_covariate_ref.csv")
+  # Filename of the continuous covariate output
+  covariateValueContFileName = file.path(exportFolder, "temporal_covariate_value_dist.csv")
+  # Filename of the analysis reference output
+  analysisRefFileName = file.path(exportFolder, "temporal_analysis_ref.csv")
+  # Filename of the time reference output
+  timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv")
+  
   jobName <- "Cohort characterization"
   task <- "runCohortCharacterization"
   ParallelLogger::logInfo("Running ", jobName)

--- a/R/runCohortCharacterization.R
+++ b/R/runCohortCharacterization.R
@@ -334,8 +334,7 @@ getCohortCharacteristics <- function(connection = NULL,
 #' @template cdmVersion 
 #' @template minCellCount 
 #' @template instantiatedCohorts 
-#' @template incremental 
-#' @template recordKeepingFile 
+#' @template Incremental
 #' @template batchSize 
 #'
 #' @param cohorts                    The cohorts for which the covariates need to be obtained
@@ -365,9 +364,30 @@ runCohortCharacterization <- function(connection,
                                       minCellCount,
                                       instantiatedCohorts,
                                       incremental,
-                                      recordKeepingFile,
+                                      incrementalFolder = exportFolder,
                                       minCharacterizationMean = 0.001,
                                       batchSize = getOption("CohortDiagnostics-FE-batch-size", default = 20)) {
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  # checkArg(cohortTable, add = errorMessage) not available
+  checkArg(tempEmulationSchema, add = errorMessage)
+  # checkArg(cohorts, add = errorMessage) not available
+  # checkArg(cohortCounts, add = errorMessage) not available
+  checkArg(minCellCount, add = errorMessage)
+  # checkArg(instantiatedCohorts, add = errorMessage) not available
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkArg(minCharacterizationMean, add = errorMessage)
+  # checkArg(batchSize, add = errorMessage) not available
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   # Filename of the binary covariates output
   covariateValueFileName = file.path(exportFolder, "temporal_covariate_value.csv")

--- a/R/runCohortRelationship.R
+++ b/R/runCohortRelationship.R
@@ -191,7 +191,6 @@ getCohortRelationship <- function(
 #' @param temporalCovariateSettings Either an object of type covariateSettings as created using one of the createTemporalCovariateSettings function in the FeatureExtraction package, or a list of such objects.
 #' @template MinCellCount 
 #' @template Incremental 
-#' @template Incremental
 #' @template BatchSize 
 #'
 #' @export
@@ -207,8 +206,26 @@ runCohortRelationship <- function(
     temporalCovariateSettings,
     minCellCount,
     incremental,
-    incrementalFolder,
+    incrementalFolder = exportFolder,
     batchSize = getOption("CohortDiagnostics-Relationship-batch-size", default = 500)) {
+  
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  # checkArg(temporalCovariateSettings, add = errorMessage) # not needed for this function as default is passed and only temporalStartDays and temporalEndDays are required from an object given.
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   cohortDefinitionSet$checksum <- CohortGenerator::computeChecksum(cohortDefinitionSet$sql)
   
@@ -236,7 +253,7 @@ runCohortRelationship <- function(
     combis = combinationsOfPossibleCohortRelationships,
     task = "runCohortRelationship",
     incremental = incremental,
-    recordKeepingFile = incrementalFolder
+    recordKeepingFile = recordKeepingFile
   )
   
   if (nrow(subset) > 0) {
@@ -379,7 +396,7 @@ runCohortRelationship <- function(
         comparatorChecksum = subset[start:end, ]$comparatorChecksum,
         task = "runCohortRelationship",
         checksum = subset[start:end, ]$checksum,
-        recordKeepingFile = incrementalFolder,
+        recordKeepingFile = recordKeepingFile,
         incremental = incremental
       )
       

--- a/R/runIncidenceRate.R
+++ b/R/runIncidenceRate.R
@@ -228,7 +228,24 @@ runIncidenceRate <- function(connection,
                              minCellCount,
                              washoutPeriod = 0,
                              incremental,
-                             recordKeepingFile) {
+                             incrementalFolder = exportFolder) {
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  # checkArg(washoutPeriod, add = errorMessage) # check not yet implemented
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   checkmate::assertIntegerish(washoutPeriod, len = 1, lower = 0)
   

--- a/R/runIncludedSourceConcepts.R
+++ b/R/runIncludedSourceConcepts.R
@@ -119,7 +119,7 @@ getIncludedSourceConcepts <- function(connection,
 #' @param cohortDatabaseSchema 
 #' @param cohortTable 
 #' @param useExternalConceptCountsTable 
-#' @param incremental 
+#' @template Incremental
 #' @param conceptIdTable 
 #' @param recordKeepingFile 
 #' @param resultsDatabaseSchema 
@@ -136,7 +136,21 @@ runIncludedSourceConcepts <- function(connection,
                                      exportFolder,
                                      minCellCount,
                                      incremental = FALSE,
-                                     recordKeepingFile) {
+                                     incrementalFolder = exportFolder) {
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   ParallelLogger::logInfo("Starting concept set diagnostics")
   start <- Sys.time()

--- a/R/runInclusionStatistics.R
+++ b/R/runInclusionStatistics.R
@@ -29,14 +29,13 @@
 #' 
 #' @template Connection
 #' @template CohortDatabaseSchema
+#' @template Incremental
 #' 
 #' @param exportFolder The folder where the output will be exported to.
 #' @param databaseId A short string for identifying the database (e.g. 'Synpuf').
 #' @param cohortDefinitionSet Data.frame of cohorts must include columns cohortId, cohortName, json, sql
 #' @param cohortTableNames Cohort Table names used by CohortGenerator package
-#' @param incremental Create only cohort diagnostics that haven't been created before?
 #' @param minCellCount The minimum cell count for fields contains person counts or fractions.
-#' @param recordKeepingFile File that keeps a record of cohorts that have been created previously
 #'
 #' @return None, it will write csv files to disk
 #' @export
@@ -48,7 +47,21 @@ runInclusionStatistics <- function(connection,
                                    cohortTableNames,
                                    minCellCount,
                                    incremental,
-                                   recordKeepingFile) {
+                                   incrementalFolder = exportFolder) {
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cohortTableNames, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   ParallelLogger::logInfo("Fetching inclusion statistics from files")
   

--- a/R/runIndexEventBreakdown.R
+++ b/R/runIndexEventBreakdown.R
@@ -225,6 +225,20 @@ runBreakdownIndexEvents <- function(connection,
                                     incremental = FALSE,
                                     incrementalFolder) {
   
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(vocabularyDatabaseSchema, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
   ParallelLogger::logInfo("Breaking down index events")
   start <- Sys.time()
   

--- a/R/runOrphanConcepts.R
+++ b/R/runOrphanConcepts.R
@@ -90,7 +90,6 @@
 #' @template MinCellCount
 #' @template CohortTable
 #' @template Incremental
-#' @template RecordKeepingFile
 #' @template CohortDatabaseSchema
 #' 
 #' @param conceptCountsDatabaseSchema Schema where the concept_counts table is located.
@@ -115,10 +114,33 @@ runOrphanConcepts <- function(connection,
                               instantiatedCodeSets = "#inst_concept_sets",
                               cohortDatabaseSchema,
                               cohortTable,
-                              incremental = FALSE,
                               conceptIdTable = NULL,
-                              recordKeepingFile,
+                              incremental = FALSE,
+                              incrementalFolder = exportFolder,
                               resultsDatabaseSchema) {
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(vocabularyDatabaseSchema, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  # checkArg(cohorts, add = errorMessage) # no argument check currently available
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  # checkArg(conceptCountsDatabaseSchema, add = errorMessage) # no argument check currently available
+  # checkArg(conceptCountsTable, add = errorMessage) # no argument check currently available
+  # checkArg(instantiatedCodeSets, add = errorMessage) # no argument check currently available
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  # checkArg(conceptIdTable, add = errorMessage) # no argument check currently available
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  # checkArg(resultsDatabaseSchema, add = errorMessage) # no argument check currently available
+  checkmate::reportAssertions(errorMessage)
+
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
+  
   ParallelLogger::logInfo("Starting concept set diagnostics")
   startTime <- Sys.time()
   subsetOrphans <- dplyr::tibble()

--- a/R/runResolvedConceptSets.R
+++ b/R/runResolvedConceptSets.R
@@ -134,6 +134,16 @@ runResolvedConceptSets <- function(connection,
                                    vocabularyDatabaseSchema,
                                    tempEmulationSchema) {
   
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(vocabularyDatabaseSchema, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
   # TODO: how should this work in incremental mode
   
   timeExecution(

--- a/R/runTimeSeries.R
+++ b/R/runTimeSeries.R
@@ -437,8 +437,7 @@ getTimeSeries <- function(
 #' @template databaseIds
 #' @template exportFolder
 #' @template minCellCount
-#' @template incremental
-#' @template IncrementalFolder
+#' @template Incremental
 #' @template BatchSize
 #' @template InstantiatedCohorts
 #' 

--- a/R/runVisitContext.R
+++ b/R/runVisitContext.R
@@ -144,26 +144,36 @@ runVisitContext <- function(connection,
                             cdmVersion = 5,
                             minCellCount,
                             incremental,
-                            incrementalFolder = file.path(exportFolder, "incremental")){
+                            incrementalFolder = exportFolder){
+  
+  errorMessage <- checkmate::makeAssertCollection()
+  checkArg(connection, add = errorMessage)
+  checkArg(cohortDefinitionSet, add = errorMessage)
+  checkArg(exportFolder, add = errorMessage)
+  checkArg(databaseId, add = errorMessage)
+  checkArg(cohortDatabaseSchema, add = errorMessage)
+  checkArg(cdmDatabaseSchema, add = errorMessage)
+  checkArg(tempEmulationSchema, add = errorMessage)
+  checkArg(cohortTable, add = errorMessage)
+  checkArg(minCellCount, add = errorMessage)
+  checkArg(incremental, add = errorMessage)
+  checkArg(incrementalFolder, add = errorMessage)
+  checkmate::reportAssertions(errorMessage)
+  
+  recordKeepingFile <- file.path(incrementalFolder, "incremental")
   
   cohortDefinitionSet$checksum <- CohortGenerator::computeChecksum(cohortDefinitionSet$sql)
   
-  # Create export file if it doesn't exist
-  if (!file.exists(gsub("/$", "", exportFolder))) {
-    dir.create(exportFolder, recursive = TRUE)
-    ParallelLogger::logInfo("Created export folder", exportFolder)
-  }
-  
-  if (incremental && !file.exists(incrementalFolder)) {
+  if (incremental && !file.exists(recordKeepingFile)) {
     # Create the file if it doesn't exist
-    file.create(incrementalFolder)
+    file.create(recordKeepingFile)
     ParallelLogger::logInfo(
       sprintf(
         "Created record keeping file %s.",
-        incrementalFolder
+        recordKeepingFile
       )
     )
-  } 
+  }
   
   cohortCounts <- CohortGenerator::getCohortCounts(
     connection = connection,
@@ -197,7 +207,7 @@ runVisitContext <- function(connection,
       dplyr::filter(.data$cohortId %in% instantiatedCohorts),
     task = "runVisitContext",
     incremental = incremental,
-    recordKeepingFile = incrementalFolder
+    recordKeepingFile = recordKeepingFile
   )
   
   if (incremental &&
@@ -242,7 +252,7 @@ runVisitContext <- function(connection,
     cohortId = subset$cohortId,
     task = "runVisitContext",
     checksum = subset$checksum,
-    recordKeepingFile = incrementalFolder,
+    recordKeepingFile = recordKeepingFile,
     incremental = incremental
   )
 }

--- a/R/runVisitContext.R
+++ b/R/runVisitContext.R
@@ -128,9 +128,6 @@ getVisitContext <- function(connection = NULL,
 #' @template cdmVersion
 #' @template MinCellCount
 #' @template Incremental
-#' @param incrementalFolder If \code{incremental = TRUE}, specify a folder where records are kept
-#'                                    of which cohort diagnostics has been executed. If not specified, a file named `incremental`  will be created inside the 
-#'                                    \code{export_folder} directory.
 #'
 #' @export
 runVisitContext <- function(connection,

--- a/tests/testthat/test-runCohortCharacterization.R
+++ b/tests/testthat/test-runCohortCharacterization.R
@@ -9,7 +9,6 @@ for (nm in names(testServers)) {
     skip_if(skipCdmTests, "cdm settings not configured")
     exportFolder <- file.path(tempdir(), paste0(nm, "exp"))
     dir.create(exportFolder)
-    recordKeepingFile <- file.path(exportFolder, "record.csv")
     on.exit(unlink(exportFolder))
     
     results <- getCohortCharacteristics(
@@ -58,7 +57,7 @@ test_that("Execute and export characterization", {
 
   with_dbc_connection(tConnection, {
     exportFolder <- tempfile()
-    recordKeepingFile <- tempfile(fileext = "csv")
+    recordKeepingFile <- file.path(exportFolder, "incremental")
     dir.create(exportFolder)
     on.exit(unlink(exportFolder), add = TRUE)
 
@@ -94,7 +93,6 @@ test_that("Execute and export characterization", {
       minCellCount = 5,
       instantiatedCohorts = server$cohortDefinitionSet$cohortId,
       incremental = TRUE,
-      recordKeepingFile = recordKeepingFile,
       minCharacterizationMean = 0.3
     )
 
@@ -141,7 +139,6 @@ test_that("Execute and export characterization", {
       minCellCount = 5,
       instantiatedCohorts = server$cohortDefinitionSet$cohortId,
       incremental = TRUE,
-      recordKeepingFile = recordKeepingFile,
       minCharacterizationMean = 0.3
     )
 

--- a/tests/testthat/test-runInclusionStatistics.R
+++ b/tests/testthat/test-runInclusionStatistics.R
@@ -7,7 +7,7 @@ for (nm in names(testServers)) {
   exportFolder <- file.path(tempdir(), paste0(nm, "exp"))
   databaseId <- "myDB"
   minCellCount <- 5
-  recordKeepingFile <- file.path(exportFolder, "record.csv")
+  recordKeepingFile <- file.path(exportFolder, "incremental")
   cohortTableNames <- CohortGenerator::getCohortTableNames(cohortTable = server$cohortTable)
 
   test_that(paste("test run inclusion statistics output", nm), {
@@ -20,8 +20,7 @@ for (nm in names(testServers)) {
                            cohortDatabaseSchema = server$cohortDatabaseSchema,
                            cohortTableNames = cohortTableNames,
                            incremental = TRUE,
-                           minCellCount = minCellCount,
-                           recordKeepingFile = recordKeepingFile)
+                           minCellCount = minCellCount)
 
     # Check cohort_inc_result
     expect_true(file.exists(file.path(exportFolder, "cohort_inc_result.csv")))

--- a/tests/testthat/test-runOrphanConcepts.R
+++ b/tests/testthat/test-runOrphanConcepts.R
@@ -40,14 +40,14 @@ for (nm in names(testServers)) {
   # incremental <- FALSE
   incremental <- TRUE
   conceptIdTable <- "#concept_ids"
-  recordKeepingFile <- file.path(exportFolder, "record.csv")
+  recordKeepingFile <- file.path(exportFolder, "incremental")
   
   # Tests
   
   test_that(paste("test run orphan codes concept table", nm), {
     connection <- DatabaseConnector::connect(server$connectionDetails)
     exportFolder <- file.path(tempdir(), paste0(nm, "_no_concept"))
-    recordKeepingFile <- file.path(exportFolder, "record.csv")
+    recordKeepingFile <- file.path(exportFolder, "incremental")
     dir.create(exportFolder)
     # CreateConceptcounts table
     
@@ -83,7 +83,6 @@ for (nm in names(testServers)) {
                       cohortTable = cohortTable,
                       incremental = incremental,
                       conceptIdTable = conceptIdTable,
-                      recordKeepingFile = recordKeepingFile,
                       resultsDatabaseSchema = resultsDatabaseSchema)
     
     # Check cohort_inc_result
@@ -151,7 +150,7 @@ for (nm in names(testServers)) {
   test_that(paste("test run orphan codes temp concept counts", nm), {
     connection <- DatabaseConnector::connect(server$connectionDetails)
     exportFolder <- file.path(tempdir(), paste0(nm, "_no_concept"))
-    recordKeepingFile <- file.path(exportFolder, "record.csv")
+    recordKeepingFile <- file.path(exportFolder, "incremental")
     dir.create(exportFolder)
     
     # Instantiate Unique ConceptSets
@@ -178,7 +177,6 @@ for (nm in names(testServers)) {
                       cohortTable = cohortTable,
                       incremental = incremental,
                       conceptIdTable = conceptIdTable,
-                      recordKeepingFile = recordKeepingFile,
                       resultsDatabaseSchema = resultsDatabaseSchema)
     
     # Check cohort_inc_result

--- a/tests/testthat/test-runVisitContext.R
+++ b/tests/testthat/test-runVisitContext.R
@@ -78,7 +78,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that when incremental is FALSE the incremental file is not generated"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     expect_false(file.exists(file.path(exportFolder,"incremental")))
 
@@ -98,7 +97,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that when incremental is TRUE the incremental file is generated when it doesn't exist"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     expect_false(file.exists(file.path(exportFolder, "incremental")))
 
@@ -120,7 +118,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that the output file visit_context.csv is generated and is identical with the output of getVisitContext()"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     getVisitContextResult <- getVisitContext(connection = con,
                                              cdmDatabaseSchema = server$cdmDatabaseSchema,
@@ -161,7 +158,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that incremental logic is correct: incremental run for the first time"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     cohortIds <- c(17492)
 
@@ -190,7 +186,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that incremental logic is correct: no new cohorts"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     cohortIds <- c(17492)
 
@@ -236,7 +231,6 @@ if ("sqlite" %in% names(testServers)) {
   test_that(paste("test that incremental logic is correct: output visit_context.csv must contain results for new cohorts"), {
 
     exportFolder <- tempfile()
-    dir.create(exportFolder)
 
     cohortIds <- c(17492)
 
@@ -478,7 +472,6 @@ test_that(paste("test that no other cohorts than the ones specified in cohortIds
                                           cdmVersion = 5
     )
 
-  print(visitContextResult)
   expect_true(identical(unique(visitContextResult$cohortId), c(1)))
 
 })


### PR DESCRIPTION
- define filenames that were previously hard-coded, all tests pass for runCohortCharacterization.R
- correct argument checks 
- replace recordKeepingFile argument with incrementalFolder for runTimeSeries, runVisitContext, runIncidenceRate, runIncludedSourceConcepts, runInclusionStatistics, runIndexEventBreakDown, runResolvedConcepts, runCohortRelationship, runCohortCharacterization.R 
- fix and adjust tests for runTimeSeries, runVisitContext, runIncidenceRate, runIncludedSourceConcepts, runInclusionStatistics, runIndexEventBreakDown, runResolvedConcepts, runCohortRelationship, runCohortCharacterization.R 